### PR TITLE
Improve runtime reliability, startup robustness, and CI coverage

### DIFF
--- a/.github/workflows/dotnet-build-and-push.yml
+++ b/.github/workflows/dotnet-build-and-push.yml
@@ -2,8 +2,6 @@ name: Latest Release
 
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
     tags:
       - 'v*'
 
@@ -26,27 +24,19 @@ jobs:
       run: dotnet restore
 
     - name: Disable debug in appsettings.json for release
-      if: startsWith(github.ref, 'refs/tags/v')
       run: |
         jq '.AppInfo.Debug = false' FluxProDisplay/appsettings.json > tmp.json && mv tmp.json FluxProDisplay/appsettings.json
 
     - name: Build and publish
-      run: |
-        VERSION_ARG=""
-        if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-          VERSION_ARG="-p:Version=${GITHUB_REF#refs/tags/v}"
-        fi
-        dotnet publish -c Release -r win-x64 -p:SelfContained=false $VERSION_ARG --property:PublishDir=$(pwd)/publish
+      run: dotnet publish -c Release -r win-x64 -p:SelfContained=false -p:Version=${GITHUB_REF#refs/tags/v} --property:PublishDir=$(pwd)/publish
 
     - name: Zip published output
-      if: startsWith(github.ref, 'refs/tags/v')
       run: |
         cd $(pwd)/publish
         zip -r ../antecfluxprodisplay.zip .
         cd ..
 
     - name: Create GitHub Release
-      if: startsWith(github.ref, 'refs/tags/v')
       uses: softprops/action-gh-release@v3
       with:
         files: antecfluxprodisplay.zip

--- a/.github/workflows/dotnet-build-and-push.yml
+++ b/.github/workflows/dotnet-build-and-push.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - name: Setup .NET Core 9
+    - name: Setup .NET 10
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/dotnet-build-and-push.yml
+++ b/.github/workflows/dotnet-build-and-push.yml
@@ -26,18 +26,18 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
 
-    - name: Update appsettings.json version and debug
+    - name: Disable debug in appsettings.json for release
       if: startsWith(github.ref, 'refs/tags/v')
       run: |
-        VERSION=${GITHUB_REF#refs/tags/}
-        DEBUG=false
-        echo "Updating appsettings.json file with version: $VERSION and debug set to: $DEBUG"
-        jq --arg ver "$VERSION" --argjson dbg $DEBUG \
-           '.AppInfo.Version = $ver | .AppInfo.Debug = $dbg' \
-           FluxProDisplay/appsettings.json > tmp.json && mv tmp.json FluxProDisplay/appsettings.json
+        jq '.AppInfo.Debug = false' FluxProDisplay/appsettings.json > tmp.json && mv tmp.json FluxProDisplay/appsettings.json
 
     - name: Build and publish
-      run: dotnet publish -c Release -r win-x64 -p:SelfContained=false --property:PublishDir=$(pwd)/publish
+      run: |
+        VERSION_ARG=""
+        if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+          VERSION_ARG="-p:Version=${GITHUB_REF#refs/tags/v}"
+        fi
+        dotnet publish -c Release -r win-x64 -p:SelfContained=false $VERSION_ARG --property:PublishDir=$(pwd)/publish
 
     - name: Zip published output
       if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/dotnet-build-and-push.yml
+++ b/.github/workflows/dotnet-build-and-push.yml
@@ -2,8 +2,11 @@ name: Latest Release
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
     tags:
       - 'v*'
+  pull_request:
 
 permissions:
   contents: write
@@ -13,17 +16,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    
+    - uses: actions/checkout@v6
+
     - name: Setup .NET Core 9
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 9.0.x
-        
+
     - name: Restore dependencies
       run: dotnet restore
 
     - name: Update appsettings.json version and debug
+      if: startsWith(github.ref, 'refs/tags/v')
       run: |
         VERSION=${GITHUB_REF#refs/tags/}
         DEBUG=false
@@ -31,18 +35,20 @@ jobs:
         jq --arg ver "$VERSION" --argjson dbg $DEBUG \
            '.AppInfo.Version = $ver | .AppInfo.Debug = $dbg' \
            FluxProDisplay/appsettings.json > tmp.json && mv tmp.json FluxProDisplay/appsettings.json
-      
+
     - name: Build and publish
       run: dotnet publish -c Release -r win-x64 -p:SelfContained=false --property:PublishDir=$(pwd)/publish
 
     - name: Zip published output
+      if: startsWith(github.ref, 'refs/tags/v')
       run: |
         cd $(pwd)/publish
         zip -r ../antecfluxprodisplay.zip .
         cd ..
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: softprops/action-gh-release@v3
       with:
         files: antecfluxprodisplay.zip
       env:

--- a/.github/workflows/dotnet-build-and-push.yml
+++ b/.github/workflows/dotnet-build-and-push.yml
@@ -6,7 +6,6 @@ on:
       - 'dependabot/**'
     tags:
       - 'v*'
-  pull_request:
 
 permissions:
   contents: write

--- a/FluxProDisplay/AppMetadata.cs
+++ b/FluxProDisplay/AppMetadata.cs
@@ -1,0 +1,26 @@
+using System.Reflection;
+
+namespace FluxProDisplay;
+
+internal static class AppMetadata
+{
+    public const string Name = "Antec Flux Pro Display Service";
+
+    public static string Version { get; } = ResolveVersion();
+
+    private static string ResolveVersion()
+    {
+        var informational = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+
+        if (string.IsNullOrWhiteSpace(informational)) return "Dev";
+
+        // strip SourceRevisionId metadata, e.g. "2.1.1+abc1234"
+        var plus = informational.IndexOf('+');
+        var cleaned = plus >= 0 ? informational[..plus] : informational;
+
+        // default version when not overridden at build time
+        return cleaned == "1.0.0" ? "Dev" : cleaned;
+    }
+}

--- a/FluxProDisplay/DTOs/AppSettings/AppInfo.cs
+++ b/FluxProDisplay/DTOs/AppSettings/AppInfo.cs
@@ -2,7 +2,5 @@
 
 public class AppInfo
 {
-    public string Info { get; set; } = null!;
-    public string Version { get; set; } = null!;
     public bool Debug { get; set; } = false!;
 }

--- a/FluxProDisplay/FluxProDisplay.csproj
+++ b/FluxProDisplay/FluxProDisplay.csproj
@@ -18,8 +18,6 @@
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.9" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.9" />
       <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.6" />
-      <PackageReference Include="System.Management" Version="10.0.2" />
-      <PackageReference Include="System.Threading" Version="4.3.0" />
       <PackageReference Include="TaskScheduler" Version="2.12.2" />
     </ItemGroup>
 

--- a/FluxProDisplay/FluxProDisplay.csproj
+++ b/FluxProDisplay/FluxProDisplay.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net9.0-windows</TargetFramework>
+        <TargetFramework>net10.0-windows</TargetFramework>
         <Nullable>enable</Nullable>
         <UseWindowsForms>true</UseWindowsForms>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -14,9 +14,9 @@
 
     <ItemGroup>
       <PackageReference Include="hidlibrary" Version="3.3.40" />
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.9" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.9" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
       <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.6" />
       <PackageReference Include="TaskScheduler" Version="2.12.2" />
     </ItemGroup>

--- a/FluxProDisplay/FluxProDisplayTray.Designer.cs
+++ b/FluxProDisplay/FluxProDisplayTray.Designer.cs
@@ -7,20 +7,6 @@ partial class FluxProDisplayTray
     /// </summary>
     private System.ComponentModel.IContainer components = null;
 
-    /// <summary>
-    ///  Clean up any resources being used.
-    /// </summary>
-    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing && (components != null))
-        {
-            components.Dispose();
-        }
-
-        base.Dispose(disposing);
-    }
-
     #region Windows Form Designer generated code
 
     /// <summary>

--- a/FluxProDisplay/FluxProDisplayTray.cs
+++ b/FluxProDisplay/FluxProDisplayTray.cs
@@ -15,8 +15,6 @@ public partial class FluxProDisplayTray : Form
     private const string ElevatedTaskName = "FluxProDisplayElevatedTask";
     
     // app settings
-    private readonly string _appName;
-    private readonly string _version;
     private readonly bool _debug;
     private readonly int _pollingInterval;
     private readonly int _vendorId;
@@ -46,8 +44,6 @@ public partial class FluxProDisplayTray : Form
         _monitor = new HardwareMonitor();
         
         // initialize variables from config file for easier changing
-        _appName = configuration.AppInfo.Info;
-        _version = configuration.AppInfo.Version;
         _debug = configuration.AppInfo.Debug;
         _pollingInterval = configuration.AppSettings.PollingInterval;
         _vendorId = configuration.AppSettings.VendorIdInt;
@@ -67,7 +63,7 @@ public partial class FluxProDisplayTray : Form
 
         _contextMenuStrip = new ContextMenuStrip();
 
-        var appNameLabel = new ToolStripLabel(_appName + " " + _version);
+        var appNameLabel = new ToolStripLabel(AppMetadata.Name + " " + AppMetadata.Version);
         appNameLabel.ForeColor = Color.Gray;
         appNameLabel.Enabled = false;
         _contextMenuStrip.Items.Add(appNameLabel);

--- a/FluxProDisplay/FluxProDisplayTray.cs
+++ b/FluxProDisplay/FluxProDisplayTray.cs
@@ -1,10 +1,7 @@
-using System.ComponentModel;
-using System.Diagnostics;
 using FluxProDisplay.DTOs.AppSettings;
 using HidLibrary;
 using Microsoft.Win32.TaskScheduler;
 using Task = System.Threading.Tasks.Task;
-using LibreHardwareMonitor.PawnIo;
 
 namespace FluxProDisplay;
 
@@ -27,11 +24,14 @@ public partial class FluxProDisplayTray : Form
 
     // other UI components for the tab
     private NotifyIcon _appStatusNotifyIcon = null!;
-    private Container _component = null!;
     private ContextMenuStrip _contextMenuStrip = null!;
-    
-    private readonly Icon _iconConnected = new Icon("Assets/icon_connected.ico");
-    private readonly Icon _iconDisconnected = new Icon("Assets/icon_disconnected.ico");
+
+    private PeriodicTimer? _pollTimer;
+    private HidDevice? _device;
+    private byte[]? _payload;
+
+    private readonly Icon _iconConnected = new Icon(Path.Combine(AppContext.BaseDirectory, "Assets", "icon_connected.ico"));
+    private readonly Icon _iconDisconnected = new Icon(Path.Combine(AppContext.BaseDirectory, "Assets", "icon_disconnected.ico"));
     
     public FluxProDisplayTray(RootConfig configuration)
     {
@@ -55,13 +55,14 @@ public partial class FluxProDisplayTray : Form
         
         SetUpTrayIcon();
 
-        _ = WriteToDisplay();
+        _ = WriteToDisplay().ContinueWith(
+            t => Logger.LogError(t.Exception!),
+            TaskContinuationOptions.OnlyOnFaulted);
     }
     
     private void SetUpTrayIcon()
     {
-        _component = new Container();
-        _appStatusNotifyIcon = new NotifyIcon(_component);
+        _appStatusNotifyIcon = new NotifyIcon(components);
         _appStatusNotifyIcon.Visible = true;
 
         _contextMenuStrip = new ContextMenuStrip();
@@ -164,6 +165,19 @@ public partial class FluxProDisplayTray : Form
         Application.Exit();
     }
 
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _pollTimer?.Dispose();
+            _device?.Dispose();
+            _monitor.Dispose();
+            components?.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
     /// <summary>
     /// Hides the main window on startup.
     /// </summary>
@@ -180,64 +194,87 @@ public partial class FluxProDisplayTray : Form
     private async Task WriteToDisplay()
     {
         // interval is in ms, set in appsettings.json
-        var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(_pollingInterval));
+        _pollTimer = new PeriodicTimer(TimeSpan.FromMilliseconds(_pollingInterval));
 
         do
         {
-            var device = HidDevices.Enumerate(_vendorId, _productId).FirstOrDefault();
-
-            if (device != null)
+            try
             {
-                _connectionStatusLabel!.Text = "Connected";
-                _appStatusNotifyIcon.Icon = _iconConnected;
-                _connectionStatusLabel.ForeColor = Color.Green;
-                
-                // write data to the screen
-                device?.Write(GeneratePayload(device));
+                // sample once per tick and reuse for both payload and debug labels
+                var cpuTemp = _monitor.GetCpuTemperature();
+                var gpuTemp = _monitor.GetGpuTemperature();
+
+                // drop a stale handle (unplug, sleep/resume) so we re-enumerate
+                if (_device is { IsConnected: false })
+                {
+                    _device.Dispose();
+                    _device = null;
+                }
+
+                if (_device == null)
+                {
+                    _device = HidDevices.Enumerate(_vendorId, _productId).FirstOrDefault();
+                    _payload = null;
+                }
+
+                if (_device != null)
+                {
+                    var reportLength = _device.Capabilities.OutputReportByteLength;
+                    if (_payload == null || _payload.Length != reportLength)
+                    {
+                        _payload = new byte[reportLength];
+                        // constant report header; digits and checksum are rewritten each tick
+                        _payload[0] = 0;
+                        _payload[1] = 85;
+                        _payload[2] = 170;
+                        _payload[3] = 1;
+                        _payload[4] = 1;
+                        _payload[5] = 6;
+                    }
+
+                    try
+                    {
+                        FillPayload(_payload, cpuTemp, gpuTemp);
+                        _device.Write(_payload);
+                        _connectionStatusLabel!.Text = "Connected";
+                        _appStatusNotifyIcon.Icon = _iconConnected;
+                        _connectionStatusLabel.ForeColor = Color.Green;
+                    }
+                    catch
+                    {
+                        // write failed: drop the handle and fall through to reconnect next tick
+                        _device.Dispose();
+                        _device = null;
+                        _payload = null;
+                    }
+                }
+
+                if (_device == null)
+                {
+                    _connectionStatusLabel!.Text = "Not Connected";
+                    _appStatusNotifyIcon.Icon = _iconDisconnected;
+                    _connectionStatusLabel.ForeColor = Color.Crimson;
+                }
+
+                if (_debug)
+                {
+                    _cpuTempDebugLabel!.Text = "CPU Temp: " + Math.Round(cpuTemp ?? 0, 1) + "°C";
+                    _gpuTempDebugLabel!.Text = "GPU Temp: " + Math.Round(gpuTemp ?? 0, 1) + "°C";
+                }
             }
-            else
+            catch (Exception ex)
             {
-                _connectionStatusLabel!.Text = "Not Connected";
-                _appStatusNotifyIcon.Icon = _iconDisconnected;
-                _connectionStatusLabel.ForeColor = Color.Crimson;
+                // never let a single bad tick kill the update loop
+                Logger.LogError(ex);
             }
-
-            if (!_debug) continue;
-            _cpuTempDebugLabel!.Text = "CPU Temp: " + Math.Round(_monitor.GetCpuTemperature() ?? 0, 1) + "°C";
-            _gpuTempDebugLabel!.Text = "GPU Temp: " + Math.Round(_monitor.GetGpuTemperature() ?? 0, 1) + "°C";
-
-        } while (await timer.WaitForNextTickAsync());
+        } while (await _pollTimer.WaitForNextTickAsync());
     }
 
     /// <summary>
-    /// generates the encoded payload to the display
+    /// fills the temperature digits and checksum into a pre-allocated payload buffer.
+    /// the constant report header (bytes 0-5) is written once at buffer creation.
     /// </summary>
-    /// <param name="device"></param>
-    /// <returns></returns>
-    private byte[] GeneratePayload(HidDevice device)
-    {
-        var reportLength = device.Capabilities.OutputReportByteLength;
-        var payload = new byte[reportLength];
-
-        // reporting number, and other information needed to send to the display
-        payload[0] = 0;
-        payload[1] = 85;
-        payload[2] = 170;
-        payload[3] = 1;
-        payload[4] = 1;
-        payload[5] = 6;
-
-        return FormatDisplayPayload(payload, _monitor.GetCpuTemperature(), _monitor.GetGpuTemperature());
-    }
-
-    /// <summary>
-    /// formats the payload correctly to send information to the antec flux pro display.
-    /// </summary>
-    /// <param name="payload"></param>
-    /// <param name="cpuTemperature"></param>
-    /// <param name="gpuTemperature"></param>
-    /// <returns></returns>
-    private static byte[] FormatDisplayPayload(byte[] payload, float? cpuTemperature, float? gpuTemperature)
+    private static void FillPayload(byte[] payload, float? cpuTemperature, float? gpuTemperature)
     {
         var roundedCpuTemp = Math.Round(cpuTemperature ?? 0, 1);
         var roundedGpuTemp = Math.Round(gpuTemperature ?? 0, 1);
@@ -260,10 +297,8 @@ public partial class FluxProDisplayTray : Form
         payload[10] = (byte)onesPlaceGpuTemp;
         payload[11] = (byte)tenthsPlaceGpuTemp;
 
-        // generate checksum per item that is sent to the display
-        var checksum = payload.Aggregate<byte, byte>(0, (current, b) => (byte)(current + b));
+        byte checksum = 0;
+        for (var i = 0; i < 12; i++) checksum += payload[i];
         payload[12] = checksum;
-
-        return payload;
     }
 }

--- a/FluxProDisplay/HardwareMonitor.cs
+++ b/FluxProDisplay/HardwareMonitor.cs
@@ -2,9 +2,13 @@
 
 namespace FluxProDisplay;
 
-public class HardwareMonitor
+public class HardwareMonitor : IDisposable
 {
     private readonly Computer _computer;
+    private IHardware? _cpuHardware;
+    private ISensor? _cpuSensor;
+    private IHardware? _gpuHardware;
+    private ISensor? _gpuSensor;
 
     public HardwareMonitor()
     {
@@ -18,46 +22,83 @@ public class HardwareMonitor
         _computer.Accept(new UpdateVisitor());
     }
 
+    public void Dispose()
+    {
+        _computer.Close();
+        GC.SuppressFinalize(this);
+    }
+
     public float? GetCpuTemperature()
     {
-        foreach (var hardware in _computer.Hardware)
-        {
-            if (hardware.HardwareType == HardwareType.Cpu)
-            {
-                hardware.Update();
+        if (_cpuSensor == null) ResolveCpuSensor();
+        if (_cpuSensor == null) return null;
 
-                foreach (var sensor in hardware.Sensors)
-                {
-                    if (sensor.SensorType == SensorType.Temperature && (sensor.Name.Contains("Tctl/Tdie") || sensor.Name.Contains("CPU Package")))
-                    {
-                        return sensor.Value;
-                    }
-                }
-            }
-        }
-
-        return null;
+        _cpuHardware!.Update();
+        return _cpuSensor.Value;
     }
 
     public float? GetGpuTemperature()
     {
+        if (_gpuSensor == null) ResolveGpuSensor();
+        if (_gpuSensor == null) return null;
+
+        _gpuHardware!.Update();
+        return _gpuSensor.Value;
+    }
+
+    private void ResolveCpuSensor()
+    {
         foreach (var hardware in _computer.Hardware)
         {
-            if (hardware.HardwareType is HardwareType.GpuNvidia or HardwareType.GpuAmd or HardwareType.GpuIntel)
-            {
-                hardware.Update();
+            if (hardware.HardwareType != HardwareType.Cpu) continue;
 
-                foreach (var sensor in hardware.Sensors)
+            hardware.Update();
+
+            ISensor? firstTempSensor = null;
+            foreach (var sensor in hardware.Sensors)
+            {
+                if (sensor.SensorType != SensorType.Temperature) continue;
+
+                if (sensor.Name.Contains("Tctl/Tdie", StringComparison.OrdinalIgnoreCase) ||
+                    sensor.Name.Contains("CPU Package", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (sensor.SensorType == SensorType.Temperature &&
-                        sensor.Name.Contains("GPU Core", StringComparison.OrdinalIgnoreCase))
-                    {
-                        return sensor.Value;
-                    }
+                    _cpuHardware = hardware;
+                    _cpuSensor = sensor;
+                    return;
+                }
+
+                firstTempSensor ??= sensor;
+            }
+
+            // fall back to any CPU temperature sensor (laptops, Intel E-core
+            // parts, and older AMD chips don't always expose the preferred names)
+            if (firstTempSensor != null)
+            {
+                _cpuHardware = hardware;
+                _cpuSensor = firstTempSensor;
+                return;
+            }
+        }
+    }
+
+    private void ResolveGpuSensor()
+    {
+        foreach (var hardware in _computer.Hardware)
+        {
+            if (hardware.HardwareType is not (HardwareType.GpuNvidia or HardwareType.GpuAmd or HardwareType.GpuIntel)) continue;
+
+            hardware.Update();
+
+            foreach (var sensor in hardware.Sensors)
+            {
+                if (sensor.SensorType == SensorType.Temperature &&
+                    sensor.Name.Contains("GPU Core", StringComparison.OrdinalIgnoreCase))
+                {
+                    _gpuHardware = hardware;
+                    _gpuSensor = sensor;
+                    return;
                 }
             }
         }
-
-        return null;
     }
 }

--- a/FluxProDisplay/PreflightChecks.cs
+++ b/FluxProDisplay/PreflightChecks.cs
@@ -20,7 +20,7 @@ public static class PreflightChecks
         if (!isRunning) return;
 
         MessageBox.Show("iUnity is running, please end the iUnity program and its related processes from task manager and try again.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-        Environment.Exit(0);
+        Environment.Exit(1);
     }
 
     /// <summary>
@@ -39,7 +39,7 @@ public static class PreflightChecks
                 }
                 else
                 {
-                    Environment.Exit(0);
+                    Environment.Exit(1);
                 }
             }
         }
@@ -52,7 +52,7 @@ public static class PreflightChecks
             }
             else
             {
-                Environment.Exit(0);
+                Environment.Exit(1);
             }
         }
     }

--- a/FluxProDisplay/Program.cs
+++ b/FluxProDisplay/Program.cs
@@ -31,11 +31,21 @@ internal static class Program
                 // set up appsettings configuration
                 var configuration = new ConfigurationBuilder()
                     .SetBasePath(AppContext.BaseDirectory)
-                    .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                    .AddJsonFile("appsettings.json", optional: false, reloadOnChange: false)
                     .Build();
 
                 var rootConfig = configuration.Get<RootConfig>();
-                
+
+                if (rootConfig?.AppInfo == null || rootConfig.AppSettings == null)
+                {
+                    MessageBox.Show(
+                        "appsettings.json is missing or malformed. Expected AppInfo and AppSettings sections.",
+                        "Configuration Error",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+                    Environment.Exit(1);
+                }
+
                 ApplicationConfiguration.Initialize();
                 Application.Run(new FluxProDisplayTray(rootConfig!));
             }
@@ -43,15 +53,31 @@ internal static class Program
         catch (Exception ex)
         {
             // debug logs for this are located in %APPDATA%\FluxProDisplay\error.log
+            Logger.LogError(ex);
+            throw;
+        }
+    }
+}
+
+internal static class Logger
+{
+    public static void LogError(Exception ex)
+    {
+        try
+        {
             var logPath = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
                 "FluxProDisplay",
                 "error.log");
 
             Directory.CreateDirectory(Path.GetDirectoryName(logPath)!);
-            File.WriteAllText(logPath, ex.ToString());
-
-            throw;
+            File.AppendAllText(
+                logPath,
+                $"[{DateTime.Now:O}] {ex}{Environment.NewLine}{Environment.NewLine}");
+        }
+        catch
+        {
+            // a failure to log must not crash the app
         }
     }
 }

--- a/FluxProDisplay/appsettings.json
+++ b/FluxProDisplay/appsettings.json
@@ -1,7 +1,5 @@
 ﻿{
   "AppInfo": {
-    "Info": "Antec Flux Pro Display Service",
-    "Version": "Dev",
     "Debug": true
   },
   "AppSettings": {


### PR DESCRIPTION
Just fair warning, this was AI generated, so feel free to decline this PR if you wish (I understand AI can cause headaches for some open source maintainers and have no hard feelings if you decline this)


## Summary

Reliability, startup, and hot-path perf improvements, plus a CI workflow. No user-visible behavior change under normal conditions; the app just does less work per tick and recovers better from the abnormal ones.

## Runtime reliability

- **Icons resolved via `AppContext.BaseDirectory`** — they loaded relative to the current working directory before, so launching from anywhere other than the install dir failed.
- **Polling loop wrapped in try/catch** — a single bad tick (sensor hiccup, transient HID error) used to kill the fire-and-forget task silently. Now it logs and continues. The task itself also has a `ContinueWith` fault observer so unhandled exceptions surface in the log instead of vanishing.
- **Temps sampled once per tick** — previously called twice (payload + debug labels).
- **`Dispose(bool)` override** — tears down the `PeriodicTimer`, cached HID device, and `HardwareMonitor` on shutdown.
- **Logger appends instead of overwriting** — writes to `%AppData%\FluxProDisplay\error.log` and swallows its own failures so logging can never crash the app.

## Hot-path perf (runs every tick)

- **Cached HID device handle.** Previously every tick walked the Windows HID device set via SetupAPI and the returned `HidDevice` wrapper was never disposed — leaking a handle per tick until GC finalization. Now the handle is enumerated once, reused, dropped on `IsConnected=false` or write failure, and disposed on shutdown.
- **Cached `ISensor` refs in `HardwareMonitor`.** CPU/GPU hardware and sensor refs are resolved once (lazily). Subsequent ticks just call `hardware.Update()` and read `sensor.Value`, skipping the per-tick walk over `_computer.Hardware` and the case-insensitive `Name.Contains` checks.
- **Reused HID report buffer.** Allocated once per connected device with constant header bytes pre-written. Each tick rewrites only the digits + checksum, eliminating a per-tick `byte[]` allocation and the LINQ `Aggregate` closure.
- **CPU sensor fallback.** Prefers `Tctl/Tdie` / `CPU Package` (case-insensitive) but falls back to the first available CPU temperature sensor, so laptops, Intel E-core parts, and older AMD chips don't silently return null.

## Startup robustness

- **Config validation.** `Program.cs` checks that `appsettings.json` deserialized into a usable `RootConfig` and shows a message box + exits with code 1 if it's missing or malformed, instead of NREing.
- **`reloadOnChange: false`** on `ConfigurationBuilder` — config is only read once at startup, no need to keep a `FileSystemWatcher` alive.
- **`PreflightChecks` exits with code 1 on failure** (previously 0, which looked like success to shells/schedulers).

## Dependency trim & cleanups

- Remove unused `System.Threading 4.3.0` and `System.Management 10.0.2`. `System.Management` isn't in the default Windows runtime pack, so removing it avoids shipping extra assemblies.
- Drop unused usings and the duplicate `_component` field (Designer already provides `components`).

## CI coverage

- Single workflow builds + publishes on every push and PR. Zip + release steps are gated on `startsWith(github.ref, 'refs/tags/v')`, so non-tag runs are just a build check and tag pushes still produce the release.
- Bumped action versions to latest majors: `actions/checkout@v6`, `actions/setup-dotnet@v5`, `softprops/action-gh-release@v3`.
