### PR TITLE
Load LibreHardwareMonitor in helper process, add dynamic loader, IPC …

### DIFF
--- a/FluxProDisplay/FluxProDisplay.csproj
+++ b/FluxProDisplay/FluxProDisplay.csproj
@@ -52,4 +52,33 @@
       </EmbeddedResource>
     </ItemGroup>
 
+  <!-- Copy helper output and any shipped LibreHardwareMonitor files into the main app output after build -->
+  <Target Name="CopyHardwareMonitorHelper" AfterTargets="Build">
+    <PropertyGroup>
+      <!-- adjust these paths if you build RID-specific outputs (net10.0-windows, win-x64, etc.) -->
+      <HelperBuildDir>$(SolutionDir)HardwareMonitorHelper\bin\$(Configuration)\net10.0</HelperBuildDir>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <HelperFiles Include="$(HelperBuildDir)\**\*.*" />
+    </ItemGroup>
+
+    <Message Text="Copying HardwareMonitorHelper files to $(OutputPath)" Importance="Low" />
+    <Copy SourceFiles="@(HelperFiles)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" />
+  </Target>
+
+  <!-- Guarded copy: copy helper output only when the helper has been built locally. -->
+  <PropertyGroup>
+    <HelperBuildDir>$(SolutionDir)HardwareMonitorHelper\bin\$(Configuration)\net10.0</HelperBuildDir>
+  </PropertyGroup>
+
+  <Target Name="CopyHardwareMonitorHelper" AfterTargets="Build" Condition="Exists('$(HelperBuildDir)')">
+    <ItemGroup>
+      <HelperFiles Include="$(HelperBuildDir)\**\*.*" />
+    </ItemGroup>
+
+    <Message Text="Copying HardwareMonitorHelper files to $(OutputPath)" Importance="Low" />
+    <Copy SourceFiles="@(HelperFiles)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" />
+  </Target>
+
 </Project>

--- a/FluxProDisplay/HardwareMonitor.cs
+++ b/FluxProDisplay/HardwareMonitor.cs
@@ -1,104 +1,298 @@
-﻿using LibreHardwareMonitor.Hardware;
+﻿using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.IO.Pipes;
+using System.Threading;
+using LibreHardwareMonitor.Hardware;
+using Microsoft.Extensions.Configuration;
 
 namespace FluxProDisplay;
 
 public class HardwareMonitor : IDisposable
 {
-    private readonly Computer _computer;
-    private IHardware? _cpuHardware;
-    private ISensor? _cpuSensor;
-    private IHardware? _gpuHardware;
-    private ISensor? _gpuSensor;
+    private const string PipeName = "FluxProDisplay_HardwareMonitor";
+    private readonly object _superviseLock = new();
+    private Process? _helperProcess;
+    private NamedPipeClientStream? _pipeStream;
+    private StreamWriter? _writer;
+    private StreamReader? _reader;
+
+    // exponential backoff state
+    private int _restartAttempts = 0;
+    private readonly int _baseBackoffMs;
+    private readonly int _maxBackoffMs;
 
     public HardwareMonitor()
     {
-        _computer = new Computer()
-        {
-            IsCpuEnabled = true,
-            IsGpuEnabled = true
-        };
+        // configurable backoff: environment variables take precedence, then appsettings.json
+        _baseBackoffMs = 500;
+        _maxBackoffMs = 300_000;
 
-        _computer.Open();
-        _computer.Accept(new UpdateVisitor());
+        try
+        {
+            var envBase = Environment.GetEnvironmentVariable("FLUX_HELPER_BACKOFF_BASE_MS");
+            var envMax = Environment.GetEnvironmentVariable("FLUX_HELPER_BACKOFF_MAX_MS");
+
+            if (!string.IsNullOrEmpty(envBase) && int.TryParse(envBase, out var eb)) _baseBackoffMs = Math.Max(1, eb);
+            if (!string.IsNullOrEmpty(envMax) && int.TryParse(envMax, out var em)) _maxBackoffMs = Math.Max(1, em);
+
+            // attempt to read appsettings.json if present (only used when env vars are not set)
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(AppContext.BaseDirectory)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false);
+
+            var config = builder.Build();
+
+            if (envBase == null)
+            {
+                var cfgBase = config.GetValue<int?>("AppSettings:HelperBackoffBaseMs");
+                if (cfgBase.HasValue) _baseBackoffMs = Math.Max(1, cfgBase.Value);
+            }
+
+            if (envMax == null)
+            {
+                var cfgMax = config.GetValue<int?>("AppSettings:HelperBackoffMaxMs");
+                if (cfgMax.HasValue) _maxBackoffMs = Math.Max(1, cfgMax.Value);
+            }
+        }
+        catch
+        {
+            // best-effort; keep defaults on any failure
+        }
+
+        EnsureHelperRunning();
     }
 
     public void Dispose()
     {
-        _computer.Close();
+        lock (_superviseLock)
+        {
+            try { _writer?.Dispose(); } catch { }
+            try { _reader?.Dispose(); } catch { }
+            try { _pipeStream?.Dispose(); } catch { }
+
+            if (_helperProcess != null && !_helperProcess.HasExited)
+            {
+                try
+                {
+                    _helperProcess.Kill(entireProcessTree: true);
+                    _helperProcess.WaitForExit(2000);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex);
+                }
+                finally
+                {
+                    _helperProcess.Dispose();
+                    _helperProcess = null;
+                }
+            }
+        }
+
         GC.SuppressFinalize(this);
     }
 
     public float? GetCpuTemperature()
     {
-        if (_cpuSensor == null) ResolveCpuSensor();
-        if (_cpuSensor == null) return null;
-
-        _cpuHardware!.Update();
-        return _cpuSensor.Value;
+        var (cpu, _) = GetTempsWithRestart();
+        return cpu;
     }
 
     public float? GetGpuTemperature()
     {
-        if (_gpuSensor == null) ResolveGpuSensor();
-        if (_gpuSensor == null) return null;
-
-        _gpuHardware!.Update();
-        return _gpuSensor.Value;
+        var (_, gpu) = GetTempsWithRestart();
+        return gpu;
     }
 
-    private void ResolveCpuSensor()
+    private (float? cpu, float? gpu) GetTempsWithRestart()
     {
-        foreach (var hardware in _computer.Hardware)
+        try
         {
-            if (hardware.HardwareType != HardwareType.Cpu) continue;
-
-            hardware.Update();
-
-            ISensor? firstTempSensor = null;
-            foreach (var sensor in hardware.Sensors)
+            return QueryHelperForTemps();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex);
+            // restart and retry once
+            RestartHelper();
+            try
             {
-                if (sensor.SensorType != SensorType.Temperature) continue;
-
-                if (sensor.Name.Contains("Tctl/Tdie", StringComparison.OrdinalIgnoreCase) ||
-                    sensor.Name.Contains("CPU Package", StringComparison.OrdinalIgnoreCase))
-                {
-                    _cpuHardware = hardware;
-                    _cpuSensor = sensor;
-                    return;
-                }
-
-                firstTempSensor ??= sensor;
+                return QueryHelperForTemps();
             }
-
-            // fall back to any CPU temperature sensor (laptops, Intel E-core
-            // parts, and older AMD chips don't always expose the preferred names)
-            if (firstTempSensor != null)
+            catch (Exception retryEx)
             {
-                _cpuHardware = hardware;
-                _cpuSensor = firstTempSensor;
-                return;
+                Logger.LogError(retryEx);
+                return (null, null);
             }
         }
     }
 
-    private void ResolveGpuSensor()
+    private (float? cpu, float? gpu) QueryHelperForTemps()
     {
-        foreach (var hardware in _computer.Hardware)
+        lock (_superviseLock)
         {
-            if (hardware.HardwareType is not (HardwareType.GpuNvidia or HardwareType.GpuAmd or HardwareType.GpuIntel)) continue;
+            EnsureHelperRunning();
 
-            hardware.Update();
+            if (_pipeStream == null || _writer == null || _reader == null)
+                throw new InvalidOperationException("IPC not initialized.");
 
-            foreach (var sensor in hardware.Sensors)
+            _writer.WriteLine("GET");
+            _writer.Flush();
+
+            var response = _reader.ReadLine();
+            if (string.IsNullOrEmpty(response)) throw new IOException("Empty response from helper.");
+
+            var parts = response.Split(';');
+            if (parts.Length != 2) throw new IOException("Malformed response.");
+
+            float? cpu = ParseNullableFloat(parts[0]);
+            float? gpu = ParseNullableFloat(parts[1]);
+
+            return (cpu, gpu);
+        }
+    }
+
+    private static float? ParseNullableFloat(string s)
+    {
+        if (string.IsNullOrEmpty(s) || s.Equals("null", StringComparison.OrdinalIgnoreCase)) return null;
+        return float.TryParse(s, System.Globalization.NumberStyles.Float, CultureInfo.InvariantCulture, out var v) ? v : (float?)null;
+    }
+
+    private void EnsureHelperRunning()
+    {
+        lock (_superviseLock)
+        {
+            if (_helperProcess != null && !_helperProcess.HasExited && _pipeStream != null && _pipeStream.IsConnected)
             {
-                if (sensor.SensorType == SensorType.Temperature &&
-                    sensor.Name.Contains("GPU Core", StringComparison.OrdinalIgnoreCase))
+                return;
+            }
+
+            try { _writer?.Dispose(); } catch { }
+            try { _reader?.Dispose(); } catch { }
+            try { _pipeStream?.Dispose(); } catch { }
+
+            _writer = null;
+            _reader = null;
+            _pipeStream = null;
+
+            var helperExe = Path.Combine(AppContext.BaseDirectory, "FluxProDisplay.HardwareMonitorHelper.exe");
+            if (!File.Exists(helperExe))
+            {
+                var ex = new FileNotFoundException("Hardware monitor helper executable not found.", helperExe);
+                Logger.LogError(ex);
+                throw ex;
+            }
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = helperExe,
+                CreateNoWindow = true,
+                UseShellExecute = false,
+                RedirectStandardOutput = false,
+                RedirectStandardError = false
+            };
+
+            try
+            {
+                _helperProcess = Process.Start(psi);
+                Logger.LogError(new Exception($"Started helper process: PID {_helperProcess?.Id}"));
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex);
+                throw;
+            }
+
+            var stream = new NamedPipeClientStream(".", PipeName, PipeDirection.InOut, PipeOptions.None);
+            try
+            {
+                stream.Connect(2000); // 2s timeout
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex);
+                try { _helperProcess?.Kill(); } catch { }
+                _helperProcess?.Dispose();
+                _helperProcess = null;
+                throw;
+            }
+
+            _pipeStream = stream;
+            _reader = new StreamReader(_pipeStream);
+            _writer = new StreamWriter(_pipeStream) { AutoFlush = true };
+
+            // Successful start/connection -> reset backoff attempts
+            _restartAttempts = 0;
+            Logger.LogError(new Exception("Connected to helper named pipe."));
+        }
+    }
+
+    private void RestartHelper()
+    {
+        lock (_superviseLock)
+        {
+            try
+            {
+                if (_helperProcess != null && !_helperProcess.HasExited)
                 {
-                    _gpuHardware = hardware;
-                    _gpuSensor = sensor;
-                    return;
+                    try
+                    {
+                        _helperProcess.Kill(entireProcessTree: true);
+                        _helperProcess.WaitForExit(2000);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogError(ex);
+                    }
+                    finally
+                    {
+                        _helperProcess.Dispose();
+                        _helperProcess = null;
+                    }
                 }
             }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex);
+            }
+
+            try { _writer?.Dispose(); } catch { }
+            try { _reader?.Dispose(); } catch { }
+            try { _pipeStream?.Dispose(); } catch { }
+
+            _writer = null;
+            _reader = null;
+            _pipeStream = null;
+
+            // increment attempts and compute backoff
+            _restartAttempts++;
+            var delay = ComputeBackoffDelay(_restartAttempts);
+            Logger.LogError(new Exception($"Restarting helper process. Attempt {_restartAttempts}, delaying {delay}ms before restart."));
+            try
+            {
+                // sleep while holding lock to prevent concurrent restarts
+                Thread.Sleep(delay);
+            }
+            catch (ThreadInterruptedException) { }
+
+            EnsureHelperRunning();
+        }
+    }
+
+    private int ComputeBackoffDelay(int attempts)
+    {
+        try
+        {
+            // exponential backoff: base * 2^(attempts-1), capped
+            var multiplier = 1L << Math.Min(attempts - 1, 30); // avoid overflow
+            var delay = Math.Min(_baseBackoffMs * multiplier, _maxBackoffMs);
+            return (int)delay;
+        }
+        catch
+        {
+            return _maxBackoffMs;
         }
     }
 }

--- a/HardwareMonitorHelper/FluxProDisplay.HardwareMonitorHelper.csproj
+++ b/HardwareMonitorHelper/FluxProDisplay.HardwareMonitorHelper.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/HardwareMonitorHelper/Program.cs
+++ b/HardwareMonitorHelper/Program.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections;
+using System.Globalization;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading;
+
+namespace FluxProDisplay.HardwareMonitorHelper;
+
+internal static class Program
+{
+    private const string PipeName = "FluxProDisplay_HardwareMonitor";
+
+    private sealed class PluginLoadContext : AssemblyLoadContext
+    {
+        private readonly AssemblyDependencyResolver _resolver;
+
+        public PluginLoadContext(string pluginPath) : base(isCollectible: true)
+        {
+            _resolver = new AssemblyDependencyResolver(pluginPath);
+        }
+
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            var path = _resolver.ResolveAssemblyToPath(assemblyName);
+            if (path != null) return LoadFromAssemblyPath(path);
+            return null;
+        }
+
+        protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
+        {
+            var path = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+            if (path != null) return LoadUnmanagedDllFromPath(path);
+            return IntPtr.Zero;
+        }
+    }
+
+    public static void Main()
+    {
+        // continuous server loop; each iteration will try to load the latest LibreHardwareMonitor DLL
+        while (true)
+        {
+            try
+            {
+                var dllPath = FindLibreHardwareMonitorDll();
+                if (dllPath == null)
+                {
+                    // nothing to load yet; sleep and retry
+                    Thread.Sleep(2000);
+                    continue;
+                }
+
+                using var alc = new PluginLoadContext(dllPath);
+                var asm = alc.LoadFromAssemblyPath(dllPath);
+
+                // required type names
+                var computerType = asm.GetType("LibreHardwareMonitor.Hardware.Computer", throwOnError: true);
+                var updateVisitorType = asm.GetType("LibreHardwareMonitor.Hardware.UpdateVisitor", throwOnError: true);
+
+                // create and initialize Computer
+                var computer = Activator.CreateInstance(computerType)!;
+                computerType.GetProperty("IsCpuEnabled")!.SetValue(computer, true);
+                computerType.GetProperty("IsGpuEnabled")!.SetValue(computer, true);
+                computerType.GetMethod("Open")!.Invoke(computer, null);
+
+                // Accept an initial update
+                var updateVisitorInstance = Activator.CreateInstance(updateVisitorType);
+                computerType.GetMethod("Accept")!.Invoke(computer, new[] { updateVisitorInstance });
+
+                // Serve a single client connection, then unload and loop to pick up updated DLLs
+                using var server = new NamedPipeServerStream(PipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Message, PipeOptions.Asynchronous);
+                server.WaitForConnection();
+
+                try
+                {
+                    using var sr = new StreamReader(server);
+                    using var sw = new StreamWriter(server) { AutoFlush = true };
+
+                    var request = sr.ReadLine();
+                    if (!string.Equals(request, "GET", StringComparison.OrdinalIgnoreCase))
+                    {
+                        sw.WriteLine("ERR");
+                    }
+                    else
+                    {
+                        // Update and read sensors via reflection
+                        computerType.GetMethod("Accept")!.Invoke(computer, new[] { Activator.CreateInstance(updateVisitorType) });
+
+                        double? cpuTemp = null;
+                        double? gpuTemp = null;
+
+                        var hardwareEnumerable = (IEnumerable)computerType.GetProperty("Hardware")!.GetValue(computer)!;
+                        foreach (var hardware in hardwareEnumerable)
+                        {
+                            try
+                            {
+                                var hwTypeObj = hardware.GetType().GetProperty("HardwareType")!.GetValue(hardware)!;
+                                var hwTypeName = hwTypeObj.ToString();
+
+                                // CPU
+                                if (string.Equals(hwTypeName, "Cpu", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    var sensors = (IEnumerable)hardware.GetType().GetProperty("Sensors")!.GetValue(hardware)!;
+                                    foreach (var sensor in sensors)
+                                    {
+                                        var sTypeObj = sensor.GetType().GetProperty("SensorType")!.GetValue(sensor)!;
+                                        if (string.Equals(sTypeObj.ToString(), "Temperature", StringComparison.OrdinalIgnoreCase))
+                                        {
+                                            var val = sensor.GetType().GetProperty("Value")!.GetValue(sensor);
+                                            if (val != null) cpuTemp = Convert.ToDouble(val, CultureInfo.InvariantCulture);
+                                            break;
+                                        }
+                                    }
+                                }
+
+                                // GPU
+                                if (string.Equals(hwTypeName, "GpuNvidia", StringComparison.OrdinalIgnoreCase) ||
+                                    string.Equals(hwTypeName, "GpuAmd", StringComparison.OrdinalIgnoreCase) ||
+                                    string.Equals(hwTypeName, "GpuIntel", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    var sensors = (IEnumerable)hardware.GetType().GetProperty("Sensors")!.GetValue(hardware)!;
+                                    foreach (var sensor in sensors)
+                                    {
+                                        var sTypeObj = sensor.GetType().GetProperty("SensorType")!.GetValue(sensor)!;
+                                        var nameObj = sensor.GetType().GetProperty("Name")!.GetValue(sensor) as string ?? string.Empty;
+                                        if (string.Equals(sTypeObj.ToString(), "Temperature", StringComparison.OrdinalIgnoreCase) &&
+                                            nameObj.IndexOf("GPU Core", StringComparison.OrdinalIgnoreCase) >= 0)
+                                        {
+                                            var val = sensor.GetType().GetProperty("Value")!.GetValue(sensor);
+                                            if (val != null) gpuTemp = Convert.ToDouble(val, CultureInfo.InvariantCulture);
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                            catch
+                            {
+                                // ignore per-hardware sensor read failures
+                            }
+                        }
+
+                        var cpuStr = cpuTemp.HasValue ? cpuTemp.Value.ToString("R", CultureInfo.InvariantCulture) : "null";
+                        var gpuStr = gpuTemp.HasValue ? gpuTemp.Value.ToString("R", CultureInfo.InvariantCulture) : "null";
+                        sw.WriteLine($"{cpuStr};{gpuStr}");
+                    }
+                }
+                catch
+                {
+                    // client disconnect / protocol error: continue to unload and restart
+                }
+                finally
+                {
+                    // close and cleanup the computer instance before unloading
+                    try { computerType.GetMethod("Close")!.Invoke(computer, null); } catch { }
+                    // allow unload
+                    alc.Unload();
+                    // give GC a chance to collect loaded assembly references so file locks are released
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    Thread.Sleep(200); // small delay to stabilize
+                }
+            }
+            catch
+            {
+                // error loading DLL or runtime failure: wait and retry
+                Thread.Sleep(1000);
+            }
+        }
+    }
+
+    private static string? FindLibreHardwareMonitorDll()
+    {
+        var baseDir = AppContext.BaseDirectory;
+        var candidates = Directory.EnumerateFiles(baseDir, "LibreHardwareMonitor*.dll", SearchOption.TopDirectoryOnly)
+            .Concat(Directory.Exists(Path.Combine(baseDir, "rhm"))
+                ? Directory.EnumerateFiles(Path.Combine(baseDir, "rhm"), "LibreHardwareMonitor*.dll", SearchOption.TopDirectoryOnly)
+                : Enumerable.Empty<string>())
+            .ToList();
+
+        if (!candidates.Any()) return null;
+        return candidates.OrderByDescending(File.GetLastWriteTimeUtc).First();
+    }
+}


### PR DESCRIPTION
…supervision, guarded deploy, and logging

Add helper process that dynamically loads LibreHardwareMonitor DLL at runtime via AssemblyLoadContext and serves CPU/GPU temperatures over a named pipe.
- Remove compile-time dependency on LibreHardwareMonitor for the helper (dynamic load).
- Replace in-process HardwareMonitor with a supervisor that starts/monitors the helper, performs IPC, and restarts helper on failure with exponential backoff. Backoff configurable via env vars or appsettings.json.
- Add guarded post-build copy target to optionally copy helper outputs into the main app output when present.
- Add logging to helper and supervisor for diagnostics.