### PR TITLE
Added option to display GPU hot spot + unified HW iteration loops

### DIFF
--- a/FluxProDisplay/Enum/DisplayModeEnum.cs
+++ b/FluxProDisplay/Enum/DisplayModeEnum.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FluxProDisplay.Enum
+{
+    internal enum DisplayModeEnum
+    {
+        CPU_GPU_PACKAGE,
+        CPU_GPU_HOTSPOT,
+        GPU_PACKAGE_GPU_HOTSPOT
+    }
+}

--- a/FluxProDisplay/FluxProDisplayTray.cs
+++ b/FluxProDisplay/FluxProDisplayTray.cs
@@ -39,6 +39,8 @@ public partial class FluxProDisplayTray : Form
     private Container _component = null!;
     private ContextMenuStrip _contextMenuStrip = null!;
 
+    private String prevFallback = String.Empty;
+
     private readonly Icon _iconConnected = new Icon("Assets/icon_connected.ico");
     private readonly Icon _iconDisconnected = new Icon("Assets/icon_disconnected.ico");
 
@@ -286,9 +288,10 @@ public partial class FluxProDisplayTray : Form
             // Compute temperatures once per tick and reuse for payload and debug
             var (payload1, payload2, fallbackMessage) = _monitor.GetTemperatures(_displayMode);
 
-            if (!string.IsNullOrEmpty(fallbackMessage))
+            if (!string.IsNullOrEmpty(fallbackMessage) && !prevFallback.Equals(fallbackMessage))
             {
                 _appStatusNotifyIcon.ShowBalloonTip(5000, "FluxProDisplay", fallbackMessage, ToolTipIcon.Info);
+                prevFallback = fallbackMessage;
             }
 
             if (device != null)

--- a/FluxProDisplay/FluxProDisplayTray.cs
+++ b/FluxProDisplay/FluxProDisplayTray.cs
@@ -1,7 +1,13 @@
+using System.ComponentModel;
+using System.Diagnostics;
 using FluxProDisplay.DTOs.AppSettings;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.IO;
 using HidLibrary;
 using Microsoft.Win32.TaskScheduler;
 using Task = System.Threading.Tasks.Task;
+using LibreHardwareMonitor.PawnIo;
 
 namespace FluxProDisplay;
 
@@ -12,62 +18,78 @@ public partial class FluxProDisplayTray : Form
     private ToolStripLabel? _cpuTempDebugLabel;
     private ToolStripLabel? _gpuTempDebugLabel;
     private ToolStripMenuItem? _startupToggleMenuItem;
+    private ToolStripMenuItem? _displayModeMenuItem;
+    private ToolStripMenuItem? _modePackageItem;
+    private ToolStripMenuItem? _modeHotspotItem;
+    private ToolStripMenuItem? _modeBothItem;
     private const string ElevatedTaskName = "FluxProDisplayElevatedTask";
-    
+
     // app settings
+    private readonly string _appName;
+    private readonly string _version;
     private readonly bool _debug;
     private readonly int _pollingInterval;
     private readonly int _vendorId;
     private readonly int _productId;
+    private int _displayMode = 0;
 
     // other UI components for the tab
     private NotifyIcon _appStatusNotifyIcon = null!;
+    private Container _component = null!;
     private ContextMenuStrip _contextMenuStrip = null!;
 
-    private PeriodicTimer? _pollTimer;
-    private HidDevice? _device;
-    private byte[]? _payload;
+    private readonly Icon _iconConnected = new Icon("Assets/icon_connected.ico");
+    private readonly Icon _iconDisconnected = new Icon("Assets/icon_disconnected.ico");
 
-    private readonly Icon _iconConnected = new Icon(Path.Combine(AppContext.BaseDirectory, "Assets", "icon_connected.ico"));
-    private readonly Icon _iconDisconnected = new Icon(Path.Combine(AppContext.BaseDirectory, "Assets", "icon_disconnected.ico"));
-    
     public FluxProDisplayTray(RootConfig configuration)
     {
         // check if iUnity is running to prevent conflicts before doing anything else
         PreflightChecks.CheckForIUnity();
-        
+
         // check if PawnIO driver is installed.
         PreflightChecks.CheckForPawnIoDriver();
-        
+
         InitializeComponent();
-        
+
         _monitor = new HardwareMonitor();
-        
+
         // initialize variables from config file for easier changing
         _debug = configuration.AppInfo.Debug;
         _pollingInterval = configuration.AppSettings.PollingInterval;
         _vendorId = configuration.AppSettings.VendorIdInt;
         _productId = configuration.AppSettings.ProductIdInt;
-        
+
         SetUpTrayIcon();
 
-        _ = WriteToDisplay().ContinueWith(
-            t => Logger.LogError(t.Exception!),
-            TaskContinuationOptions.OnlyOnFaulted);
+        // ensure we dispose monitor on form closing
+        this.FormClosing += FluxProDisplayTray_FormClosing;
+
+        UpdateDisplayModeMenuChecks();
+
+        _ = WriteToDisplay();
     }
-    
+
+    private void FluxProDisplayTray_FormClosing(object? sender, FormClosingEventArgs e)
+    {
+        try { _monitor?.Dispose(); } catch { }
+        try { _appStatusNotifyIcon?.Dispose(); } catch { }
+        try { _component?.Dispose(); } catch { }
+        try { _contextMenuStrip?.Dispose(); } catch { }
+    }
+
     private void SetUpTrayIcon()
     {
-        _appStatusNotifyIcon = new NotifyIcon(components);
+        _component = new Container();
+        _appStatusNotifyIcon = new NotifyIcon(_component);
         _appStatusNotifyIcon.Visible = true;
 
         _contextMenuStrip = new ContextMenuStrip();
 
-        var appNameLabel = new ToolStripLabel(AppMetadata.Name + " " + AppMetadata.Version);
+        var appNameLabel = new ToolStripLabel(_appName + " " + _version);
         appNameLabel.ForeColor = Color.Gray;
         appNameLabel.Enabled = false;
         _contextMenuStrip.Items.Add(appNameLabel);
-        
+
         // debug item that shows current temperature in menu strip
         if (_debug)
         {
@@ -85,12 +107,25 @@ public partial class FluxProDisplayTray : Form
         _startupToggleMenuItem = new ToolStripMenuItem();
         _startupToggleMenuItem.Click += StartupToggleMenuItemClicked;
 
+        // display mode submenu
+        _displayModeMenuItem = new ToolStripMenuItem("Display Mode");
+        _modePackageItem = new ToolStripMenuItem("CPU + GPU Package");
+        _modeHotspotItem = new ToolStripMenuItem("CPU + GPU Hotspot");
+        _modeBothItem = new ToolStripMenuItem("GPU Hotspot + Package");
+
+        _modePackageItem.Click += (s, e) => ChangeDisplayMode(0, true);
+        _modeHotspotItem.Click += (s, e) => ChangeDisplayMode(1, true);
+        _modeBothItem.Click += (s, e) => ChangeDisplayMode(2, true);
+
+        _displayModeMenuItem.DropDownItems.AddRange(new ToolStripItem[] { _modePackageItem, _modeHotspotItem, _modeBothItem });
+
         var quitMenuItem = new ToolStripMenuItem("Quit");
         quitMenuItem.Click += QuitMenuItem_Click!;
 
         // separator to separate
         _contextMenuStrip.Items.Add(new ToolStripSeparator());
         _contextMenuStrip.Items.Add(_startupToggleMenuItem);
+        _contextMenuStrip.Items.Add(_displayModeMenuItem);
         _contextMenuStrip.Items.Add(quitMenuItem);
 
         _appStatusNotifyIcon.ContextMenuStrip = _contextMenuStrip;
@@ -107,12 +142,12 @@ public partial class FluxProDisplayTray : Form
         debugModeLabel.ForeColor = Color.Gray;
         debugModeLabel.Enabled = false;
         _contextMenuStrip.Items.Add(debugModeLabel);
-            
+
         _cpuTempDebugLabel = new ToolStripLabel("CPU Temp: 0°C");
         _cpuTempDebugLabel.ForeColor = Color.Gray;
         _cpuTempDebugLabel.Enabled = false;
         _contextMenuStrip.Items.Add(_cpuTempDebugLabel);
-            
+
         _gpuTempDebugLabel = new ToolStripLabel("GPU Temp: 0°C");
         _gpuTempDebugLabel.ForeColor = Color.Gray;
         _gpuTempDebugLabel.Enabled = false;
@@ -149,6 +184,69 @@ public partial class FluxProDisplayTray : Form
         UpdateStartupMenuItemText();
     }
 
+    private void ChangeDisplayMode(int mode, bool persist = true)
+    {
+        _displayMode = mode;
+        UpdateDisplayModeMenuChecks();
+        // persist to appsettings.json
+        if (!persist)
+            return;
+
+        try
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, "appsettings.json");
+            if (!File.Exists(path))
+                return;
+
+            var text = File.ReadAllText(path);
+            var root = JsonNode.Parse(text) ?? new JsonObject();
+
+            if (root["AppSettings"] == null || root["AppSettings"].GetType() != typeof(JsonObject))
+            {
+                root["AppSettings"] = new JsonObject();
+            }
+
+            var appSettings = root["AppSettings"].AsObject();
+            // only write if value changed to avoid unnecessary overwrites at startup
+            int? existing = null;
+            try
+            {
+                if (appSettings["DisplayMode"] != null)
+                {
+                    existing = appSettings["DisplayMode"].GetValue<int?>();
+                }
+            }
+            catch { existing = null; }
+
+            if (existing == mode)
+                return;
+
+            appSettings["DisplayMode"] = mode;
+
+            File.WriteAllText(path, root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+
+            // log persistence for debugging
+            try
+            {
+                var logPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "FluxProDisplay", "persist.log");
+                Directory.CreateDirectory(Path.GetDirectoryName(logPath)!);
+                File.AppendAllText(logPath, DateTime.UtcNow.ToString("o") + " - Wrote DisplayMode=" + mode + " to appsettings.json\n");
+            }
+            catch { }
+        }
+        catch
+        {
+            // ignore persistence errors
+        }
+    }
+
+    private void UpdateDisplayModeMenuChecks()
+    {
+        _modePackageItem!.Checked = _displayMode == 0;
+        _modeHotspotItem!.Checked = _displayMode == 1;
+        _modeBothItem!.Checked = _displayMode == 2;
+    }
+
     private void UpdateStartupMenuItemText()
     {
         using var ts = new TaskService();
@@ -161,26 +259,14 @@ public partial class FluxProDisplayTray : Form
         Application.Exit();
     }
 
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            _pollTimer?.Dispose();
-            _device?.Dispose();
-            _monitor.Dispose();
-            components?.Dispose();
-        }
-
-        base.Dispose(disposing);
-    }
-
     /// <summary>
     /// Hides the main window on startup.
     /// </summary>
     /// <param name="value"></param>
     protected override void SetVisibleCore(bool value)
     {
-        if (!IsHandleCreated) {
+        if (!IsHandleCreated)
+        {
             value = false;
             CreateHandle();
         }
@@ -190,87 +276,75 @@ public partial class FluxProDisplayTray : Form
     private async Task WriteToDisplay()
     {
         // interval is in ms, set in appsettings.json
-        _pollTimer = new PeriodicTimer(TimeSpan.FromMilliseconds(_pollingInterval));
+        var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(_pollingInterval));
 
         do
         {
-            try
+            var device = HidDevices.Enumerate(_vendorId, _productId).FirstOrDefault();
+
+            // Compute temperatures once per tick and reuse for payload and debug
+            var (payload1, payload2, fallbackMessage) = _monitor.GetTemperatures(_displayMode);
+
+            if (!string.IsNullOrEmpty(fallbackMessage))
             {
-                // sample once per tick and reuse for both payload and debug labels
-                var cpuTemp = _monitor.GetCpuTemperature();
-                var gpuTemp = _monitor.GetGpuTemperature();
-
-                // drop a stale handle (unplug, sleep/resume) so we re-enumerate
-                if (_device is { IsConnected: false })
-                {
-                    _device.Dispose();
-                    _device = null;
-                }
-
-                if (_device == null)
-                {
-                    _device = HidDevices.Enumerate(_vendorId, _productId).FirstOrDefault();
-                    _payload = null;
-                }
-
-                if (_device != null)
-                {
-                    var reportLength = _device.Capabilities.OutputReportByteLength;
-                    if (_payload == null || _payload.Length != reportLength)
-                    {
-                        _payload = new byte[reportLength];
-                        // constant report header; digits and checksum are rewritten each tick
-                        _payload[0] = 0;
-                        _payload[1] = 85;
-                        _payload[2] = 170;
-                        _payload[3] = 1;
-                        _payload[4] = 1;
-                        _payload[5] = 6;
-                    }
-
-                    try
-                    {
-                        FillPayload(_payload, cpuTemp, gpuTemp);
-                        _device.Write(_payload);
-                        _connectionStatusLabel!.Text = "Connected";
-                        _appStatusNotifyIcon.Icon = _iconConnected;
-                        _connectionStatusLabel.ForeColor = Color.Green;
-                    }
-                    catch
-                    {
-                        // write failed: drop the handle and fall through to reconnect next tick
-                        _device.Dispose();
-                        _device = null;
-                        _payload = null;
-                    }
-                }
-
-                if (_device == null)
-                {
-                    _connectionStatusLabel!.Text = "Not Connected";
-                    _appStatusNotifyIcon.Icon = _iconDisconnected;
-                    _connectionStatusLabel.ForeColor = Color.Crimson;
-                }
-
-                if (_debug)
-                {
-                    _cpuTempDebugLabel!.Text = "CPU Temp: " + Math.Round(cpuTemp ?? 0, 1) + "°C";
-                    _gpuTempDebugLabel!.Text = "GPU Temp: " + Math.Round(gpuTemp ?? 0, 1) + "°C";
-                }
+                _appStatusNotifyIcon.ShowBalloonTip(5000, "FluxProDisplay", fallbackMessage, ToolTipIcon.Info);
             }
-            catch (Exception ex)
+
+            if (device != null)
             {
-                // never let a single bad tick kill the update loop
-                Logger.LogError(ex);
+                _connectionStatusLabel!.Text = "Connected";
+                _appStatusNotifyIcon.Icon = _iconConnected;
+                _connectionStatusLabel.ForeColor = Color.Green;
+
+                // write data to the screen using precomputed payloads
+                device?.Write(GeneratePayload(device, payload1, payload2));
             }
-        } while (await _pollTimer.WaitForNextTickAsync());
+            else
+            {
+                _connectionStatusLabel!.Text = "Not Connected";
+                _appStatusNotifyIcon.Icon = _iconDisconnected;
+                _connectionStatusLabel.ForeColor = Color.Crimson;
+            }
+
+            if (!_debug) continue;
+
+            _cpuTempDebugLabel!.Text = "Payload1: " + Math.Round(payload1 ?? 0, 1) + "°C";
+            _gpuTempDebugLabel!.Text = "Payload2: " + Math.Round(payload2 ?? 0, 1) + "°C";
+
+        } while (await timer.WaitForNextTickAsync());
     }
 
     /// <summary>
-    /// fills the temperature digits and checksum into a pre-allocated payload buffer.
-    /// the constant report header (bytes 0-5) is written once at buffer creation.
+    /// generates the encoded payload to the display
     /// </summary>
-    private static void FillPayload(byte[] payload, float? cpuTemperature, float? gpuTemperature)
+    /// <param name="device"></param>
+    /// <returns></returns>
+    private byte[] GeneratePayload(HidDevice device, float? payload1, float? payload2)
+    {
+        var reportLength = device.Capabilities.OutputReportByteLength;
+        var payload = new byte[reportLength];
+
+        // reporting number, and other information needed to send to the display
+        payload[0] = 0;
+        payload[1] = 85;
+        payload[2] = 170;
+        payload[3] = 1;
+        payload[4] = 1;
+        payload[5] = 6;
+
+        return FormatDisplayPayload(payload, payload1, payload2);
+    }
+
+
+
+    /// <summary>
+    /// formats the payload correctly to send information to the antec flux pro display.
+    /// </summary>
+    /// <param name="payload"></param>
+    /// <param name="cpuTemperature"></param>
+    /// <param name="gpuTemperature"></param>
+    /// <returns></returns>
+    private static byte[] FormatDisplayPayload(byte[] payload, float? cpuTemperature, float? gpuTemperature)
     {
         var roundedCpuTemp = Math.Round(cpuTemperature ?? 0, 1);
         var roundedGpuTemp = Math.Round(gpuTemperature ?? 0, 1);
@@ -293,8 +367,10 @@ public partial class FluxProDisplayTray : Form
         payload[10] = (byte)onesPlaceGpuTemp;
         payload[11] = (byte)tenthsPlaceGpuTemp;
 
-        byte checksum = 0;
-        for (var i = 0; i < 12; i++) checksum += payload[i];
+        // generate checksum per item that is sent to the display
+        var checksum = payload.Aggregate<byte, byte>(0, (current, b) => (byte)(current + b));
         payload[12] = checksum;
+
+        return payload;
     }
 }

--- a/FluxProDisplay/FluxProDisplayTray.cs
+++ b/FluxProDisplay/FluxProDisplayTray.cs
@@ -8,6 +8,7 @@ using HidLibrary;
 using Microsoft.Win32.TaskScheduler;
 using Task = System.Threading.Tasks.Task;
 using LibreHardwareMonitor.PawnIo;
+using FluxProDisplay.Enum;
 
 namespace FluxProDisplay;
 
@@ -31,7 +32,7 @@ public partial class FluxProDisplayTray : Form
     private readonly int _pollingInterval;
     private readonly int _vendorId;
     private readonly int _productId;
-    private int _displayMode = 0;
+    private DisplayModeEnum _displayMode = 0;
 
     // other UI components for the tab
     private NotifyIcon _appStatusNotifyIcon = null!;
@@ -113,9 +114,9 @@ public partial class FluxProDisplayTray : Form
         _modeHotspotItem = new ToolStripMenuItem("CPU + GPU Hotspot");
         _modeBothItem = new ToolStripMenuItem("GPU Hotspot + Package");
 
-        _modePackageItem.Click += (s, e) => ChangeDisplayMode(0, true);
-        _modeHotspotItem.Click += (s, e) => ChangeDisplayMode(1, true);
-        _modeBothItem.Click += (s, e) => ChangeDisplayMode(2, true);
+        _modePackageItem.Click += (s, e) => ChangeDisplayMode(DisplayModeEnum.CPU_GPU_PACKAGE, true);
+        _modeHotspotItem.Click += (s, e) => ChangeDisplayMode(DisplayModeEnum.CPU_GPU_HOTSPOT, true);
+        _modeBothItem.Click += (s, e) => ChangeDisplayMode(DisplayModeEnum.GPU_PACKAGE_GPU_HOTSPOT, true);
 
         _displayModeMenuItem.DropDownItems.AddRange(new ToolStripItem[] { _modePackageItem, _modeHotspotItem, _modeBothItem });
 
@@ -184,7 +185,7 @@ public partial class FluxProDisplayTray : Form
         UpdateStartupMenuItemText();
     }
 
-    private void ChangeDisplayMode(int mode, bool persist = true)
+    private void ChangeDisplayMode(DisplayModeEnum mode, bool persist = true)
     {
         _displayMode = mode;
         UpdateDisplayModeMenuChecks();
@@ -208,12 +209,12 @@ public partial class FluxProDisplayTray : Form
 
             var appSettings = root["AppSettings"].AsObject();
             // only write if value changed to avoid unnecessary overwrites at startup
-            int? existing = null;
+            DisplayModeEnum? existing = null;
             try
             {
                 if (appSettings["DisplayMode"] != null)
                 {
-                    existing = appSettings["DisplayMode"].GetValue<int?>();
+                    existing = appSettings["DisplayMode"].GetValue<DisplayModeEnum?>();
                 }
             }
             catch { existing = null; }
@@ -221,7 +222,7 @@ public partial class FluxProDisplayTray : Form
             if (existing == mode)
                 return;
 
-            appSettings["DisplayMode"] = mode;
+            appSettings["DisplayMode"] = (int)mode;
 
             File.WriteAllText(path, root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
 
@@ -242,9 +243,9 @@ public partial class FluxProDisplayTray : Form
 
     private void UpdateDisplayModeMenuChecks()
     {
-        _modePackageItem!.Checked = _displayMode == 0;
-        _modeHotspotItem!.Checked = _displayMode == 1;
-        _modeBothItem!.Checked = _displayMode == 2;
+        _modePackageItem!.Checked = _displayMode == DisplayModeEnum.CPU_GPU_PACKAGE;
+        _modeHotspotItem!.Checked = _displayMode == DisplayModeEnum.CPU_GPU_HOTSPOT;
+        _modeBothItem!.Checked = _displayMode == DisplayModeEnum.GPU_PACKAGE_GPU_HOTSPOT;
     }
 
     private void UpdateStartupMenuItemText()

--- a/FluxProDisplay/HardwareMonitor.cs
+++ b/FluxProDisplay/HardwareMonitor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using FluxProDisplay.Enum;
 using LibreHardwareMonitor.Hardware;
 using LibreHardwareMonitor.Hardware.Cpu;
 
@@ -33,23 +34,28 @@ public class HardwareMonitor : IDisposable
     /// Returns tuple: (cpuTemp, gpuForPayload, gpuHotspot, gpuPackage, resultingDisplayMode, didFallback)
     /// </summary>
     // returns payload1, payload2 and an optional fallback message (non-null when a fallback occurred)
-    public (float? payload1, float? payload2, string? fallbackMessage) GetTemperatures(int displayMode)
+    internal (float? payload1, float? payload2, string? fallbackMessage) GetTemperatures(DisplayModeEnum displayMode)
     {
         float? cpuTemp = null;
         float? gpuHotspot = null;
         float? gpuPackage = null;
-        float? gpuFallbackTemp = null;
         string? fallbackMessage = null;
+
+        // determine which sensors are required for the requested display mode
+        bool needCpu = displayMode == DisplayModeEnum.CPU_GPU_PACKAGE
+                       || displayMode == DisplayModeEnum.CPU_GPU_HOTSPOT;
+        bool needGpuHotspot = displayMode == DisplayModeEnum.CPU_GPU_HOTSPOT
+                              || displayMode == DisplayModeEnum.GPU_PACKAGE_GPU_HOTSPOT;
+        bool needGpuPackage = displayMode == DisplayModeEnum.CPU_GPU_PACKAGE
+                              || displayMode == DisplayModeEnum.GPU_PACKAGE_GPU_HOTSPOT;
 
         lock (_sync)
         {
             if (_disposed)
                 return (null, null, null);
 
-            // single pass through hardware; iterate each hardware's sensors only once
             foreach (var hardware in _computer.Hardware)
             {
-                // only process CPU and GPU hardware
                 if (hardware.HardwareType != HardwareType.Cpu &&
                     hardware.HardwareType != HardwareType.GpuNvidia &&
                     hardware.HardwareType != HardwareType.GpuAmd &&
@@ -60,8 +66,6 @@ public class HardwareMonitor : IDisposable
                 var sensors = hardware.Sensors.Where(sensor => sensor.SensorType == SensorType.Temperature).ToList();
                 foreach (var sensor in sensors)
                 {
-
-                    // ensure sensor has valid value
                     if (!sensor.Value.HasValue)
                         continue;
                     var val = sensor.Value.Value;
@@ -70,7 +74,6 @@ public class HardwareMonitor : IDisposable
 
                     var name = sensor.Name ?? string.Empty;
 
-                    // CPU temperature sensors
                     if (hardware.HardwareType == HardwareType.Cpu && cpuTemp == null)
                     {
                         if (name.Contains("Tctl/Tdie") || name.Contains("CPU Package"))
@@ -78,27 +81,24 @@ public class HardwareMonitor : IDisposable
                             cpuTemp = val;
                         }
                     }
-
                     else
                     {
                         if (gpuHotspot == null && name.Contains("Hot Spot", StringComparison.OrdinalIgnoreCase))
-                        {
                             gpuHotspot = val;
-                        }
 
                         if (gpuPackage == null && name.Contains("Core", StringComparison.OrdinalIgnoreCase))
-                        {
                             gpuPackage = val;
-                        }
-
-                        if (gpuFallbackTemp == null)
-                            gpuFallbackTemp = val;
                     }
-                }
 
-                if (cpuTemp == null || gpuHotspot == null || gpuPackage == null)
-                    continue;
-                break; // if we've found all relevant temps, no need to continue iterating through hardware
+                    // stop early only when all sensors required by the display mode were found
+                    if ((!needCpu || cpuTemp != null) &&
+                        (!needGpuHotspot || gpuHotspot != null) &&
+                        (!needGpuPackage || gpuPackage != null))
+                    {
+                        break;
+                    }
+
+                }
             }
         }
         // map to opaque payloads according to displayMode
@@ -107,33 +107,44 @@ public class HardwareMonitor : IDisposable
 
         switch (displayMode)
         {
-            case 0: // payload1 = CPU, payload2 = GPU package
+            case DisplayModeEnum.CPU_GPU_PACKAGE:
                 payload1 = cpuTemp;
-                payload2 = gpuPackage ?? gpuFallbackTemp;
+                if (gpuPackage != null)
+                {
+                    payload2 = gpuPackage;
+                    break;
+                }
+                fallbackMessage = "GPU Package not found, using hotspot GPU temperature as fallback.";
+                payload2 = gpuHotspot;
                 break;
-            case 1: // payload1 = CPU, payload2 = GPU hotspot (fallback to package)
+            case DisplayModeEnum.CPU_GPU_HOTSPOT:
                 payload1 = cpuTemp;
                 if (gpuHotspot != null)
                 {
                     payload2 = gpuHotspot;
+                    break;
                 }
-                else
+                fallbackMessage = "GPU Hot Spot found, using  GPU Package as fallback.";
+                payload2 = gpuPackage;
+                break;        
+            case DisplayModeEnum.GPU_PACKAGE_GPU_HOTSPOT:
+                payload1 = gpuPackage;
+                payload2 = gpuHotspot;
+                // local helper to append with newline only when needed
+                static string AppendMsg(string? existing, string addition) =>
+                    string.IsNullOrEmpty(existing) ? addition : existing + Environment.NewLine + addition;
+                if (gpuPackage == null)
                 {
-                    payload2 = gpuPackage ?? gpuFallbackTemp;
-                    fallbackMessage = "GPU Hot Spot not found, switching to GPU Package temperature.";
+                    fallbackMessage = "GPU gpuPackage temperature not found.";
                 }
-                break;
-            case 2:
-                payload1 = gpuPackage ?? gpuFallbackTemp;
-                payload2 = gpuHotspot ?? payload1;
-                if (gpuHotspot == null && (gpuPackage != null || gpuFallbackTemp != null))
+                if (gpuHotspot == null)
                 {
-                    fallbackMessage = "GPU Hot Spot not found, using GPU Package temperature.";
+                    fallbackMessage = AppendMsg(fallbackMessage, "GPU Hot Spot not found.");
                 }
                 break;
             default:
-                payload1 = cpuTemp;
-                payload2 = gpuPackage ?? gpuFallbackTemp;
+                payload1 = payload2 = 0;
+                fallbackMessage = "Unsupported or invalid display mode";
                 break;
         }
 

--- a/FluxProDisplay/HardwareMonitor.cs
+++ b/FluxProDisplay/HardwareMonitor.cs
@@ -31,7 +31,7 @@ public class HardwareMonitor : IDisposable
     /// 0 = Cpu + Gpu Package
     /// 1 = Cpu + Gpu Hotspot (fallback to package)
     /// 2 = Gpu Hotspot + Package
-    /// Returns tuple: (cpuTemp, gpuForPayload, gpuHotspot, gpuPackage, resultingDisplayMode, didFallback)
+    /// Returns tuple: (payload1, payload2, fallbackMessage)
     /// </summary>
     // returns payload1, payload2 and an optional fallback message (non-null when a fallback occurred)
     internal (float? payload1, float? payload2, string? fallbackMessage) GetTemperatures(DisplayModeEnum displayMode)
@@ -124,7 +124,7 @@ public class HardwareMonitor : IDisposable
                     payload2 = gpuHotspot;
                     break;
                 }
-                fallbackMessage = "GPU Hot Spot found, using  GPU Package as fallback.";
+                fallbackMessage = "GPU Hot Spot not found, using  GPU Package as fallback.";
                 payload2 = gpuPackage;
                 break;        
             case DisplayModeEnum.GPU_PACKAGE_GPU_HOTSPOT:

--- a/FluxProDisplay/HardwareMonitor.cs
+++ b/FluxProDisplay/HardwareMonitor.cs
@@ -1,14 +1,15 @@
-﻿using LibreHardwareMonitor.Hardware;
+﻿using System;
+using System.Linq;
+using LibreHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Hardware.Cpu;
 
 namespace FluxProDisplay;
 
 public class HardwareMonitor : IDisposable
 {
     private readonly Computer _computer;
-    private IHardware? _cpuHardware;
-    private ISensor? _cpuSensor;
-    private IHardware? _gpuHardware;
-    private ISensor? _gpuSensor;
+    private readonly object _sync = new object();
+    private bool _disposed;
 
     public HardwareMonitor()
     {
@@ -22,83 +23,147 @@ public class HardwareMonitor : IDisposable
         _computer.Accept(new UpdateVisitor());
     }
 
+
+    /// <summary>
+    /// Reads CPU and GPU sensors in a single pass and returns temperatures based on display mode.
+    /// displayMode:
+    /// 0 = Cpu + Gpu Package
+    /// 1 = Cpu + Gpu Hotspot (fallback to package)
+    /// 2 = Gpu Hotspot + Package
+    /// Returns tuple: (cpuTemp, gpuForPayload, gpuHotspot, gpuPackage, resultingDisplayMode, didFallback)
+    /// </summary>
+    // returns payload1, payload2 and an optional fallback message (non-null when a fallback occurred)
+    public (float? payload1, float? payload2, string? fallbackMessage) GetTemperatures(int displayMode)
+    {
+        float? cpuTemp = null;
+        float? gpuHotspot = null;
+        float? gpuPackage = null;
+        float? gpuFallbackTemp = null;
+        string? fallbackMessage = null;
+
+        lock (_sync)
+        {
+            if (_disposed)
+                return (null, null, null);
+
+            // single pass through hardware; iterate each hardware's sensors only once
+            foreach (var hardware in _computer.Hardware)
+            {
+                // only process CPU and GPU hardware
+                if (hardware.HardwareType != HardwareType.Cpu &&
+                    hardware.HardwareType != HardwareType.GpuNvidia &&
+                    hardware.HardwareType != HardwareType.GpuAmd &&
+                    hardware.HardwareType != HardwareType.GpuIntel)
+                    continue;
+
+                hardware.Update();
+                var sensors = hardware.Sensors.Where(sensor => sensor.SensorType == SensorType.Temperature).ToList();
+                foreach (var sensor in sensors)
+                {
+
+                    // ensure sensor has valid value
+                    if (!sensor.Value.HasValue)
+                        continue;
+                    var val = sensor.Value.Value;
+                    if (float.IsNaN(val) || float.IsInfinity(val))
+                        continue;
+
+                    var name = sensor.Name ?? string.Empty;
+
+                    // CPU temperature sensors
+                    if (hardware.HardwareType == HardwareType.Cpu && cpuTemp == null)
+                    {
+                        if (name.Contains("Tctl/Tdie") || name.Contains("CPU Package"))
+                        {
+                            cpuTemp = val;
+                        }
+                    }
+
+                    else
+                    {
+                        if (gpuHotspot == null && name.Contains("Hot Spot", StringComparison.OrdinalIgnoreCase))
+                        {
+                            gpuHotspot = val;
+                        }
+
+                        if (gpuPackage == null && name.Contains("Core", StringComparison.OrdinalIgnoreCase))
+                        {
+                            gpuPackage = val;
+                        }
+
+                        if (gpuFallbackTemp == null)
+                            gpuFallbackTemp = val;
+                    }
+                }
+
+                if (cpuTemp == null || gpuHotspot == null || gpuPackage == null)
+                    continue;
+                break; // if we've found all relevant temps, no need to continue iterating through hardware
+            }
+        }
+        // map to opaque payloads according to displayMode
+        float? payload1 = null;
+        float? payload2 = null;
+
+        switch (displayMode)
+        {
+            case 0: // payload1 = CPU, payload2 = GPU package
+                payload1 = cpuTemp;
+                payload2 = gpuPackage ?? gpuFallbackTemp;
+                break;
+            case 1: // payload1 = CPU, payload2 = GPU hotspot (fallback to package)
+                payload1 = cpuTemp;
+                if (gpuHotspot != null)
+                {
+                    payload2 = gpuHotspot;
+                }
+                else
+                {
+                    payload2 = gpuPackage ?? gpuFallbackTemp;
+                    fallbackMessage = "GPU Hot Spot not found, switching to GPU Package temperature.";
+                }
+                break;
+            case 2:
+                payload1 = gpuPackage ?? gpuFallbackTemp;
+                payload2 = gpuHotspot ?? payload1;
+                if (gpuHotspot == null && (gpuPackage != null || gpuFallbackTemp != null))
+                {
+                    fallbackMessage = "GPU Hot Spot not found, using GPU Package temperature.";
+                }
+                break;
+            default:
+                payload1 = cpuTemp;
+                payload2 = gpuPackage ?? gpuFallbackTemp;
+                break;
+        }
+
+        return (payload1, payload2, fallbackMessage);
+    }
+
     public void Dispose()
     {
-        _computer.Close();
-        GC.SuppressFinalize(this);
-    }
-
-    public float? GetCpuTemperature()
-    {
-        if (_cpuSensor == null) ResolveCpuSensor();
-        if (_cpuSensor == null) return null;
-
-        _cpuHardware!.Update();
-        return _cpuSensor.Value;
-    }
-
-    public float? GetGpuTemperature()
-    {
-        if (_gpuSensor == null) ResolveGpuSensor();
-        if (_gpuSensor == null) return null;
-
-        _gpuHardware!.Update();
-        return _gpuSensor.Value;
-    }
-
-    private void ResolveCpuSensor()
-    {
-        foreach (var hardware in _computer.Hardware)
+        lock (_sync)
         {
-            if (hardware.HardwareType != HardwareType.Cpu) continue;
-
-            hardware.Update();
-
-            ISensor? firstTempSensor = null;
-            foreach (var sensor in hardware.Sensors)
-            {
-                if (sensor.SensorType != SensorType.Temperature) continue;
-
-                if (sensor.Name.Contains("Tctl/Tdie", StringComparison.OrdinalIgnoreCase) ||
-                    sensor.Name.Contains("CPU Package", StringComparison.OrdinalIgnoreCase))
-                {
-                    _cpuHardware = hardware;
-                    _cpuSensor = sensor;
-                    return;
-                }
-
-                firstTempSensor ??= sensor;
-            }
-
-            // fall back to any CPU temperature sensor (laptops, Intel E-core
-            // parts, and older AMD chips don't always expose the preferred names)
-            if (firstTempSensor != null)
-            {
-                _cpuHardware = hardware;
-                _cpuSensor = firstTempSensor;
+            if (_disposed)
                 return;
-            }
-        }
-    }
 
-    private void ResolveGpuSensor()
-    {
-        foreach (var hardware in _computer.Hardware)
-        {
-            if (hardware.HardwareType is not (HardwareType.GpuNvidia or HardwareType.GpuAmd or HardwareType.GpuIntel)) continue;
-
-            hardware.Update();
-
-            foreach (var sensor in hardware.Sensors)
+            try
             {
-                if (sensor.SensorType == SensorType.Temperature &&
-                    sensor.Name.Contains("GPU Core", StringComparison.OrdinalIgnoreCase))
-                {
-                    _gpuHardware = hardware;
-                    _gpuSensor = sensor;
-                    return;
-                }
+                _computer.Close();
             }
+            catch
+            {
+                // ignore
+            }
+
+            if (_computer is IDisposable d)
+            {
+                try { d.Dispose(); } catch { }
+            }
+
+            _disposed = true;
         }
+
+        GC.SuppressFinalize(this);
     }
 }


### PR DESCRIPTION
Added an option for monitoring hot spot temperature of the GPU, and different display modes:

- CPU + GPU Core
- CPU + GPU Hotspot
- GPU Core +  GPU hotspot

For that purpose, along with other code modifications, I generalized the monitoring method to collect the data according to the display mode, instead of a fixed CPU then GPU cores temperatures. Also iterating the IHardware list once instead of for CPU and GPU separately.

I use this at my home PC and it works good. However, tested only with the Radeon 9070 XT which is what I have, not with any NVIDIA or other AMD GPU, but thought about sharing anyway, for your consideration.

If you would like to accept this PR, next I could make the display mode persistent, which is something added in my local code and not pushed so far.